### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ description = "Run pkg-config from declarative dependencies in Cargo.toml"
 keywords = ["pkg-config", "build-dependencies", "build-depends", "manifest", "metadata"]
 
 [dependencies]
-error-chain = { version = "0.7.1", default-features = false }
+error-chain = { version = "0.10", default-features = false }
 pkg-config = "0.3.8"
-toml = { version = "0.2", default-features = false }
+toml = "0.4"
 
 [dev-dependencies]
 lazy_static = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,10 @@ pub fn probe() -> Result<HashMap<String, Library>> {
         format!("Error parsing TOML from {}: {:?}", path.display(), e)
     ));
     let key = "package.metadata.pkg-config";
-    let meta = try!(toml.lookup(key).ok_or(
-        format!("No {} in {}", key, path.display())
-    ));
+    let meta = try!(toml.get("package")
+                        .and_then(|v| v.get("metadata"))
+                        .and_then(|v| v.get("pkg-config"))
+                        .ok_or(format!("No {} in {}", key, path.display())));
     let table = try!(meta.as_table().ok_or(
         format!("{} not a table in {}", key, path.display())
     ));


### PR DESCRIPTION
This updates:
* error-chain from 0.7.1 to 0.10.x, which doesn't require any code change
* toml from 0.2.x to 0.4.x, which removes `toml::Value::lookup` and thus need to expand the code a bit