### PR TITLE
Bump error-chain to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Run pkg-config from declarative dependencies in Cargo.toml"
 keywords = ["pkg-config", "build-dependencies", "build-depends", "manifest", "metadata"]
 
 [dependencies]
-error-chain = { version = "0.10", default-features = false }
+error-chain = { version = "0.11", default-features = false }
 pkg-config = "0.3.8"
 toml = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
This doesn't require any code change and also have the nice effect of
fixing tests since rustc was emitting some warnings about unused doc
comments with 0.10.