### PR TITLE
Fix fmt, warnings, upgrade deps and port to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["pkg-config", "build-dependencies", "build-depends", "manifest", "me
 [dependencies]
 error-chain = { version = "0.12", default-features = false }
 pkg-config = "0.3.8"
-toml = { version = "0.2", default-features = false }
+toml = { version = "0.5", default-features = false }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Run pkg-config from declarative dependencies in Cargo.toml"
 keywords = ["pkg-config", "build-dependencies", "build-depends", "manifest", "metadata"]
 
 [dependencies]
-error-chain = { version = "0.10", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 pkg-config = "0.3.8"
 toml = { version = "0.2", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/joshtriplett/metadeps"
 description = "Run pkg-config from declarative dependencies in Cargo.toml"
 keywords = ["pkg-config", "build-dependencies", "build-depends", "manifest", "metadata"]
+edition = "2018"
 
 [dependencies]
 error-chain = { version = "0.12", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 
 #[macro_use]
 extern crate error_chain;
-extern crate pkg_config;
-extern crate toml;
 
 use pkg_config::{Config, Library};
 use std::collections::HashMap;
@@ -57,8 +55,8 @@ pub fn probe() -> Result<HashMap<String, Library>> {
     let mut libraries = HashMap::new();
     for (name, value) in table {
         let version = match value {
-            &toml::Value::String(ref s) => s,
-            &toml::Value::Table(ref t) => {
+            toml::Value::String(ref s) => s,
+            toml::Value::Table(ref t) => {
                 let mut feature = None;
                 let mut version = None;
                 for (tname, tvalue) in t {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub fn probe() -> Result<HashMap<String, Library>> {
         .ok_or(format!("{} not a table in {}", key, path.display()))?;
     let mut libraries = HashMap::new();
     for (name, value) in table {
-        let ref version = match value {
+        let version = match value {
             &toml::Value::String(ref s) => s,
             &toml::Value::Table(ref t) => {
                 let mut feature = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ pub fn probe() -> Result<HashMap<String, Library>> {
         .map_err(|e| format!("Error parsing TOML from {}: {:?}", path.display(), e))?;
     let key = "package.metadata.pkg-config";
     let meta = toml
-        .lookup(key)
+        .get("package")
+        .and_then(|v| v.get("metadata"))
+        .and_then(|v| v.get("pkg-config"))
         .ok_or(format!("No {} in {}", key, path.display()))?;
     let table = meta
         .as_table()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate lazy_static;
-extern crate metadeps;
-extern crate pkg_config;
 
 use std::env;
 use std::sync::Mutex;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,8 +12,14 @@ lazy_static! {
 
 fn toml(path: &str) -> metadeps::Result<std::collections::HashMap<String, pkg_config::Library>> {
     let _l = LOCK.lock();
-    env::set_var("PKG_CONFIG_PATH", &env::current_dir().unwrap().join("tests"));
-    env::set_var("CARGO_MANIFEST_DIR", &env::current_dir().unwrap().join("tests").join(path));
+    env::set_var(
+        "PKG_CONFIG_PATH",
+        &env::current_dir().unwrap().join("tests"),
+    );
+    env::set_var(
+        "CARGO_MANIFEST_DIR",
+        &env::current_dir().unwrap().join("tests").join(path),
+    );
     env::set_var("CARGO_FEATURE_TEST_FEATURE", "");
     metadeps::probe()
 }
@@ -31,7 +37,10 @@ fn good() {
 fn toml_err(path: &str, err_starts_with: &str) {
     let err = toml(path).unwrap_err();
     if !err.description().starts_with(err_starts_with) {
-        panic!("Expected error to start with: {:?}\nGot error: {:?}", err_starts_with, err);
+        panic!(
+            "Expected error to start with: {:?}\nGot error: {:?}",
+            err_starts_with, err
+        );
     }
 }
 
@@ -47,30 +56,48 @@ fn missing_key() {
 
 #[test]
 fn not_table() {
-    toml_err("toml-not-table", "package.metadata.pkg-config not a table in");
+    toml_err(
+        "toml-not-table",
+        "package.metadata.pkg-config not a table in",
+    );
 }
 
 #[test]
 fn version_missing() {
-    toml_err("toml-version-missing", "No version in package.metadata.pkg-config.testlib");
+    toml_err(
+        "toml-version-missing",
+        "No version in package.metadata.pkg-config.testlib",
+    );
 }
 
 #[test]
 fn version_not_string() {
-    toml_err("toml-version-not-string", "package.metadata.pkg-config.testlib not a string or table");
+    toml_err(
+        "toml-version-not-string",
+        "package.metadata.pkg-config.testlib not a string or table",
+    );
 }
 
 #[test]
 fn version_in_table_not_string() {
-    toml_err("toml-version-in-table-not-string", "Unexpected key package.metadata.pkg-config.testlib.version type integer");
+    toml_err(
+        "toml-version-in-table-not-string",
+        "Unexpected key package.metadata.pkg-config.testlib.version type integer",
+    );
 }
 
 #[test]
 fn feature_not_string() {
-    toml_err("toml-feature-not-string", "Unexpected key package.metadata.pkg-config.testlib.feature type integer");
+    toml_err(
+        "toml-feature-not-string",
+        "Unexpected key package.metadata.pkg-config.testlib.feature type integer",
+    );
 }
 
 #[test]
 fn unexpected_key() {
-    toml_err("toml-unexpected-key", "Unexpected key package.metadata.pkg-config.testlib.color type string");
+    toml_err(
+        "toml-unexpected-key",
+        "Unexpected key package.metadata.pkg-config.testlib.color type string",
+    );
 }


### PR DESCRIPTION
A bunch of patches modernizing `metadeps`.

I realize some of those are redundant with existing PRs but most of those were outdated and/or were including multiple changes in the same commit. I recorded each one separately so we can easily drop some if desired, especially the controversial `toml` dep bump.

@joshtriplett : is `metadeps` still maintained? I'm interested experimenting with it and tailor it for our needs (`gtk-rs` crates mostly) so I'm happy to fork it if you don't plan to keep working it. :)